### PR TITLE
Add mutation engine prototype with mock CST and Node class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,68 @@
-# Ignore JetBrains IDE settings
+# Python environment and packages
+.venv/
+venv/
+env/
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+PIPFILE.lock
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+
+# IDE settings
 .idea/
-
-# Ignore VSCode settings
 .vscode/
+*.swp
+*.swo
+*~
+.project
+.pydevproject
+.settings/
+*.sublime-project
+*.sublime-workspace
 
-# Ignore node_modules folder (for JS projects)
-node_modules/
-
-# Ignore environment variable files
-.env
-
-# Ignore system files
+# OS-specific files
 .DS_Store
 Thumbs.db
- 
+.Spotlight-V100
+.Trashes
+
+# Node.js (if used)
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# IDE-specific directories
+.vscode/settings.json
+.vscode/extensions.json

--- a/prototype/__init__.py
+++ b/prototype/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/prototype/mock/__init__.py
+++ b/prototype/mock/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/prototype/mock/mock_cst.py
+++ b/prototype/mock/mock_cst.py
@@ -1,0 +1,27 @@
+"""Mock Concrete Syntax Tree (CST) for testing and demonstration.
+
+This module provides a sample CST representing a simple function definition.
+It's used for testing mutation rules and the mutation engine.
+
+The sample CST represents the following pseudocode:
+    add(a, b) { return a + b; }
+"""
+
+from ..node import Node
+
+cst = Node("function_definition", [
+    Node("identifier", text="add"),
+    Node("parameters", [
+        Node("identifier", text="a"),
+        Node("identifier", text="b")
+    ]),
+    Node("body", [
+        Node("return_statement", [
+            Node("binary_expression", [
+                Node("identifier", text="a"),
+                Node("operator", text="+"),
+                Node("identifier", text="b")
+            ])
+        ])
+    ])
+])

--- a/prototype/mutation/__init__.py
+++ b/prototype/mutation/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/prototype/mutation/mutate.py
+++ b/prototype/mutation/mutate.py
@@ -1,0 +1,40 @@
+"""Main module for demonstrating mutation of a Concrete Syntax Tree (CST).
+
+This module provides a simple entry point that loads a mock CST, applies
+mutation rules (specifically identifier renaming), and displays the results.
+
+Usage:
+    python -m prototype.mutation.mutate
+"""
+
+from ..mock.mock_cst import cst
+from .mutation_rule import RenameIdentifiersRule
+from .mutation_engine import MutationEngine
+
+
+def main():
+    """Main function that demonstrates CST mutation.
+    
+    This function:
+    1. Loads a mock CST (a simple function definition)
+    2. Prints the original tree structure
+    3. Creates a MutationEngine with RenameIdentifiersRule
+    4. Applies the mutation rules to transform the tree
+    5. Prints the mutated tree structure
+    
+    The mutation rule prefixes all identifiers with "x_", so:
+    - 'add' becomes 'x_add'
+    - 'a' becomes 'x_a'
+    - 'b' becomes 'x_b'
+    """
+    print("Before mutation:")
+    cst.pretty()
+
+    engine = MutationEngine([RenameIdentifiersRule()])
+    mutated = engine.applyMutations(cst)
+
+    print("\nAfter mutation:")
+    mutated.pretty()
+
+if __name__ == '__main__':
+    main()

--- a/prototype/mutation/mutation_engine.py
+++ b/prototype/mutation/mutation_engine.py
@@ -1,0 +1,45 @@
+"""Mutation Engine for applying transformation rules to Concrete Syntax Trees (CST).
+
+The MutationEngine orchestrates the application of one or more mutation rules to a CST,
+allowing systematic transformation and modification of code structure.
+"""
+
+
+class MutationEngine:
+    """Engine for applying mutation rules to transform syntax trees.
+    
+    The MutationEngine takes a list of mutation rules and applies them sequentially
+    to a Concrete Syntax Tree (CST). Each rule transforms the tree in place.
+    
+    Attributes:
+        rules (list): List of mutation rules to apply. Each rule must have an apply() method.
+    """
+    
+    def __init__(self, rules):
+        """Initialize the MutationEngine with a list of rules.
+        
+        Args:
+            rules (list): List of mutation rule objects. Each rule should implement
+                an apply(node) method that transforms the node and its children.
+        """
+        self.rules = rules
+    
+    def applyMutations(self, cst):
+        """Apply all mutation rules to the given CST.
+        
+        Rules are applied sequentially. The output of one rule becomes the input
+        to the next rule. This allows for composable transformations.
+        
+        Args:
+            cst (Node): The root node of the Concrete Syntax Tree to mutate.
+        
+        Returns:
+            Node: The transformed syntax tree after all rules have been applied.
+        
+        Example:
+            >>> engine = MutationEngine([RenameIdentifiersRule()])
+            >>> mutated_tree = engine.applyMutations(original_tree)
+        """
+        for rule in self.rules:
+            cst = rule.apply(cst)
+        return cst

--- a/prototype/mutation/mutation_rule.py
+++ b/prototype/mutation/mutation_rule.py
@@ -1,0 +1,45 @@
+"""Mutation rules for transforming Abstract/Concrete Syntax Trees.
+
+This module defines concrete mutation rules that can be applied to transform
+syntax trees. Each rule implements a specific transformation strategy.
+"""
+
+
+class RenameIdentifiersRule:
+    """A mutation rule that renames all identifiers in the tree.
+    
+    This rule applies a prefix "x_" to all identifier nodes in a syntax tree.
+    It recursively traverses the tree and modifies each identifier's text.
+    
+    Example:
+        Before: Node(type='identifier', text='add')
+        After:  Node(type='identifier', text='x_add')
+    """
+    
+    def apply(self, node):
+        """Apply the rename transformation to an identifier node and its descendants.
+        
+        This method recursively traverses the syntax tree and prefixes all identifier
+        nodes with "x_". Non-identifier nodes are passed through unchanged but their
+        children are still processed.
+        
+        Args:
+            node (Node): The root node to transform. Can be any node type.
+        
+        Returns:
+            Node: The same node with identifiers renamed (modified in place).
+        
+        Example:
+            >>> rule = RenameIdentifiersRule()
+            >>> tree = Node('identifier', text='x')
+            >>> result = rule.apply(tree)
+            >>> result.text
+            'x_x'
+        """
+        if node.type == "identifier" and node.text is not None:
+            node.text = "x_" + node.text
+        
+        for child in node.children:
+            self.apply(child)
+        
+        return node

--- a/prototype/node.py
+++ b/prototype/node.py
@@ -1,0 +1,79 @@
+class Node:
+    """Represents a node in an Abstract Syntax Tree (AST) or Concrete Syntax Tree (CST).
+    
+    A Node is a fundamental building block for representing program structure as a tree.
+    Each node has a type (e.g., "identifier", "binary_expression"), optional child nodes,
+    and optional text content (for leaf nodes like tokens).
+    
+    Attributes:
+        type (str): The node type/category (e.g., "identifier", "function_definition", "binary_expression").
+        children (list): List of child Node objects. Represents the structure of the tree.
+        text (str, optional): The raw token text for leaf nodes. None for non-leaf nodes.
+    """
+    
+    def __init__(self, type, children=None, text=None):
+        """Initialize a new Node.
+        
+        Args:
+            type (str): The node type/category identifier.
+            children (list, optional): List of child Node objects. Defaults to empty list if None.
+            text (str, optional): Raw token text for leaf nodes. Defaults to None.
+        """
+        self.type = type
+        self.children = children or []
+        self.text = text
+
+    def add_child(self, child):
+        """Add a child node to this node.
+        
+        Args:
+            child (Node): The child node to add.
+        """
+        self.children.append(child)
+
+    def traverse(self):
+        """Yield all nodes in the tree using preorder traversal.
+        
+        Preorder traversal visits the current node before visiting its children.
+        This is useful for visiting nodes in a top-down order.
+        
+        Yields:
+            Node: Each node in the tree in preorder sequence.
+        """
+        yield self
+        for child in self.children:
+            yield from child.traverse()
+
+    def __repr__(self):
+        """Return a string representation of the node.
+        
+        Returns:
+            str: A string showing the node type and text (if present).
+        """
+        return f"Node(type={self.type}, text={self.text})"
+
+    def pretty(self, indent=0):
+        """Print a human-readable tree representation of this node and its children.
+        
+        This method recursively prints the tree structure with proper indentation.
+        Each level of nesting is indented by 2 spaces.
+        
+        Args:
+            indent (int, optional): Current indentation level. Defaults to 0 (root level).
+                Used internally for recursive calls.
+        
+        Example:
+            >>> node = Node("function_definition", text="add")
+            >>> node.pretty()
+            function_definition: add
+        """
+        prefix = "  " * indent
+        line = f"{prefix}{self.type}"
+
+        if self.text is not None:
+            line += f": {self.text}"
+
+        print(line)
+
+        for child in self.children:
+            child.pretty(indent + 1)


### PR DESCRIPTION
Core CST and mutation framework:

* Added the `Node` class in `prototype/node.py` to represent syntax tree nodes, including methods for traversal, adding children, and printing the tree structure.
* Introduced the `MutationEngine` class in `prototype/mutation/mutation_engine.py` to orchestrate the application of mutation rules to CSTs, allowing sequential and composable transformations.
* Implemented the `RenameIdentifiersRule` in `prototype/mutation/mutation_rule.py`, which recursively prefixes all identifier nodes with `"x_"` in the CST.

Demonstration and mock data:

* Created `prototype/mock/mock_cst.py`, which defines a sample CST for a simple function (`add(a, b) { return a + b; }`) to be used in mutation demonstrations.
* Added `prototype/mutation/mutate.py` as a main entry point for demonstrating CST mutation, showing before-and-after tree structures using the mock CST and mutation rule.