### PR TITLE
Feature/transformation control structure substitution

### DIFF
--- a/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_strategies/for_loop_strategies/cpp_strategy.py
+++ b/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_strategies/for_loop_strategies/cpp_strategy.py
@@ -15,6 +15,10 @@ into an equivalent while-loop:
 
 from typing import List, Optional
 
+from tests.mutation.rules.control_structure_substitution.test_control_structure_substitution import (
+    rule,
+)
+
 from ......node import Node
 from .....mutation_context import MutationContext
 from ....mutation_rule import MutationRule, MutationRecord
@@ -76,8 +80,10 @@ class CppForLoopStrategy(CstyleForLoopStrategy):
         update_source = self._emit_stmt(update_node.to_code()) if update_node else None
 
         # Delete init and update nodes from the for loop header and clean up remaining formatting tokens
-        records.extend(self._delete_nodes([init_node], rule))
-        records.extend(self._delete_nodes([update_node], rule))
+        if init_node is not None:
+            records.extend(self._delete_nodes([init_node], rule))
+        if update_node is not None:
+            records.extend(self._delete_nodes([update_node], rule))
         records.extend(self._clean_for_loop_header(node, rule))
 
         records.append(self._substitute(for_node, "while", "while", rule))

--- a/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_strategies/for_loop_strategies/cpp_strategy.py
+++ b/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_strategies/for_loop_strategies/cpp_strategy.py
@@ -15,10 +15,6 @@ into an equivalent while-loop:
 
 from typing import List, Optional
 
-from tests.mutation.rules.control_structure_substitution.test_control_structure_substitution import (
-    rule,
-)
-
 from ......node import Node
 from .....mutation_context import MutationContext
 from ....mutation_rule import MutationRule, MutationRecord

--- a/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_strategies/for_loop_strategies/cstyle_for_loop_strategy.py
+++ b/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_strategies/for_loop_strategies/cstyle_for_loop_strategy.py
@@ -126,7 +126,7 @@ class CstyleForLoopStrategy(BaseForLoopStrategy):
                 inside = True
             elif c.type == ")":
                 inside = False
-            elif inside and c.type in ("whitespace", ";", ","):
+            elif inside and c.type in ("whitespace", "newline", ";", ","):
                 nodes_to_delete.append(c)
 
         for n in nodes_to_delete:

--- a/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_substitution.py
+++ b/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_substitution.py
@@ -6,7 +6,6 @@ but is designed to support additional control structures (e.g., ternary)
 in the future.
 """
 
-from multiprocessing import context
 from typing import List
 
 from ....node import Node


### PR DESCRIPTION
Fixes a bug where newlines weren't removed from loop headers.