### PR TITLE
Adds level support for for -> rule transformations

### DIFF
--- a/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_substitution.py
+++ b/src/transtructiver/mutation/rules/control_structure_substitution/control_structure_substitution.py
@@ -6,7 +6,8 @@ but is designed to support additional control structures (e.g., ternary)
 in the future.
 """
 
-from typing import List
+import random
+from typing import Dict, List
 
 from ....node import Node
 from ..mutation_rule import MutationRule, MutationRecord
@@ -28,7 +29,15 @@ class ControlStructureSubstitutionRule(MutationRule):
 
     rule_name = "control-structure-substitution"
 
-    def __init__(self, level: int = 0):
+    # Mapping of transformation levels to the percentage of applicable targets to transform.
+    LEVEL_RATIOS: Dict[int, float] = {
+        0: 0.10,  # Minimal: 10% of targets
+        1: 0.35,  # Low: 35% of targets
+        2: 0.65,  # Medium: 65% of targets
+        3: 1.00,  # Maximum: 100% of targets
+    }
+
+    def __init__(self, level: int = 0, seed: int = 42):
         """
         Initialize the rule with a specified transformation level passed to rename-identifiers rule,"
         "or 0 for default.
@@ -38,6 +47,7 @@ class ControlStructureSubstitutionRule(MutationRule):
         """
         super().__init__()
         self._level = level
+        self._rng = random.Random(seed)
 
     def apply(self, root: Node, context: MutationContext) -> List[MutationRecord]:
         """
@@ -67,7 +77,6 @@ class ControlStructureSubstitutionRule(MutationRule):
         ]
 
         targets: List[tuple[BaseControlStructureStrategy, Node]] = []
-
         indent_unit = IndentationUtils.detect_indent_unit(root)
 
         for node in root.traverse():
@@ -83,8 +92,15 @@ class ControlStructureSubstitutionRule(MutationRule):
 
         context.taken_names = taken_names
 
+        if not targets:
+            return []
+
+        ratio = self.LEVEL_RATIOS.get(self._level, 0.15)
+        num_to_transform = max(1, round(len(targets) * ratio))
+        selected_targets = self._rng.sample(targets, num_to_transform)
+
         # Apply transformations
-        for strategy, node in targets:
+        for strategy, node in selected_targets:
             records.extend(strategy.apply(node, self, context, indent_unit, self._level))
 
         return records

--- a/transtructiver.config.yaml
+++ b/transtructiver.config.yaml
@@ -35,7 +35,9 @@ transformations:
       indent_unit: null                     # Default: null
 
   control-structure-substitution:
-    enabled: true
+    enabled: false
+    params:
+      level: 0                              # Default: 0
 
 # Verifier thresholds and strictness
 verifier:


### PR DESCRIPTION
Adds level support for for -> rule transformations:

        Level 0: 0.10,  # Minimal: 10% of targets
        Level 1: 0.35,  # Low: 35% of targets
        Level 2: 0.65,  # Medium: 65% of targets
        Level 3: 1.00,  # Maximum: 100% of targets
   
1 target is always substituted if there are valid targets.