### PR TITLE
Add level support for CommentDeletionRule

### DIFF
--- a/src/transtructiver/mutation/rules/comment_deletion.py
+++ b/src/transtructiver/mutation/rules/comment_deletion.py
@@ -1,14 +1,13 @@
 """comment_deletion.py
 
-Defines the CommentDeletion mutation rule, which removes all comment nodes
-from a Concrete Syntax Tree (CST). Each deletion generates a MutationRecord
-capturing the original source coordinates and content of the removed comment.
-
-This module provides a concrete implementation of the MutationRule interface
-for comment removal, supporting downstream verification and manifest generation.
+Defines the CommentDeletion mutation rule, which removes comment nodes
+from a Concrete Syntax Tree (CST) proportionally based on a mutation level. 
+Each deletion generates a MutationRecord capturing the original source 
+coordinates and content of the removed comment.
 """
 
-from typing import List
+import random
+from typing import Dict, List
 
 from transtructiver.mutation.mutation_context import MutationContext
 from .mutation_rule import MutationRule, MutationRecord
@@ -17,39 +16,73 @@ from ...node import Node
 
 class CommentDeletionRule(MutationRule):
     """
-    Concrete mutation rule that deletes all comment nodes from a CST.
+    Concrete mutation rule that deletes comment nodes from a CST.
 
+    The number of comments deleted is proportional to the mutation level.
     Each deletion generates a MutationRecord with the node's original coordinates.
+
+    Attributes:
+        rule_name (str): CLI identifier for the rule.
+        LEVEL_RATIOS (Dict[int, float]): Mapping of levels to deletion density.
     """
 
     # CLI rule name (used by the auto-discovery in cli.py).
     rule_name = "comment-deletion"
 
+    # Mapping of levels to the percentage of comments to be deleted.
+    LEVEL_RATIOS: Dict[int, float] = {
+        0: 0.10,  # Minimal: 10% of comments
+        1: 0.35,  # Low: 35% of comments
+        2: 0.65,  # Medium: 65% of comments
+        3: 1.00,  # Maximum: 100% of comments
+    }
+
+    def __init__(self, level: int = 0, seed: int = 42):
+        """
+        Initialize the CommentDeletionRule with a specified level and random seed.
+
+        Args:
+            level (int): The mutation level (0-3) determining the percentage of comments to delete.
+            seed (int): Random seed used to initialize the RNG for reproducible sampling.
+        """
+        super().__init__()
+        self._level = level
+        self._rng = random.Random(seed)
+
     def apply(self, root: Node, context: MutationContext) -> List[MutationRecord]:
         """
-        Apply the CommentDeletion mutation rule to the CST.
+        Apply the CommentDeletion mutation rule to the CST proportionally.
 
-        This method recursively traverses the tree rooted at `root`,
-        removes any nodes of type "comment", and returns a list of
-        MutationRecords describing each deletion.
+        Collects all eligible comment nodes, determines the number to delete
+        based on the level, and performs the deletions using a seeded RNG.
 
         Args:
             root (Node): The root node of the CST to mutate.
-            context (MutationContext): The context object for tracking mutation state,
-                                       not used in this rule but included for interface consistency.
+            context (MutationContext): Context for tracking mutation state.
 
         Returns:
-            List[MutationRecord]: A list of all deletions performed,
-            each containing the original coordinates and text content of the removed comment.
+            List[MutationRecord]: A list of all deletions performed, each containing
+                the original coordinates and text content of the removed comment.
         """
-        records: List[MutationRecord] = []
+        if root is None:
+            return []
 
-        for child in list(root.children):
-            if child.semantic_label in ["line_comment", "block_comment"]:
-                record = self.record_delete(root, child)
-                records.append(record)
-            else:
-                # Recursively process child nodes
-                records.extend(self.apply(child, context))
+        records: List[MutationRecord] = []
+        comment_targets: List[tuple[Node, Node]] = []
+
+        for node in root.traverse():
+            for child in node.children:
+                if child.semantic_label in ["line_comment", "block_comment"]:
+                    comment_targets.append((node, child))
+
+        if not comment_targets:
+            return []
+
+        ratio = self.LEVEL_RATIOS.get(self._level, 0.10)
+        num_to_delete = max(1, round(len(comment_targets) * ratio))
+        selected_deletions = self._rng.sample(comment_targets, num_to_delete)
+
+        for parent, child in selected_deletions:
+            records.append(self.record_delete(parent, child))
 
         return records

--- a/tests/mutation/rules/test_comment_deletion.py
+++ b/tests/mutation/rules/test_comment_deletion.py
@@ -95,7 +95,7 @@ def collect_comment_labels(root: Node):
 @pytest.fixture
 def comment_rule():
     """Fixture providing a reusable CommentDeletion instance."""
-    return CommentDeletionRule()
+    return CommentDeletionRule(level=3)
 
 
 @pytest.fixture


### PR DESCRIPTION
Adds level support for CommentDeletionRule

        Level 0: 0.10,  # Minimal: 10% of targets
        Level 1: 0.35,  # Low: 35% of targets
        Level 2: 0.65,  # Medium: 65% of targets
        Level 3: 1.00,  # Maximum: 100% of targets
   
1 target is always deleted if there are valid targets.