### PR TITLE
Add format-only replacement strategy for comment normalization

### DIFF
--- a/src/transtructiver/mutation/rules/comment_normalization/_format_only.py
+++ b/src/transtructiver/mutation/rules/comment_normalization/_format_only.py
@@ -1,0 +1,58 @@
+"""Format-only replacement strategy for comment normalization."""
+
+import re
+import unicodedata
+
+from ....node import Node
+
+_LINE_DELIMITERS = ("//", "#", "--")
+_BLOCK_DELIMITERS = (("/**", "*/"), ("/*", "*/"), ('"""', '"""'), ("'''", "'''"))
+
+
+def _is_normalized_character(character: str) -> bool:
+    """Allow letters, numbers, whitespace, and ordinary punctuation."""
+    if character in {"\ufe0f", "\u200d"}:
+        return False
+
+    category = unicodedata.category(character)
+    return category.startswith(("L", "N", "P")) or character.isspace()
+
+
+def _normalize_written_content(text: str) -> str:
+    """Remove non-text symbols and normalize spacing while preserving newlines."""
+
+    def _normalize_line(line: str) -> str:
+        without_symbols = "".join(
+            character for character in line if _is_normalized_character(character)
+        )
+        normalized = re.sub(r"\s+", " ", without_symbols).strip()
+        return re.sub(r"\s+([!?.,;:)\]\}])", r"\1", normalized)
+
+    lines = text.splitlines()
+    if len(lines) <= 1:
+        return _normalize_line(text)
+
+    normalized_lines = [_normalize_line(line) for line in lines]
+    return "\n".join(line for line in normalized_lines if line)
+
+
+def _replace_format_only(node: Node, _ancestor: Node) -> str:
+    """Return the comment's written content with normalized spacing and symbols."""
+
+    if not node.text:
+        return ""
+
+    stripped_text = node.text.strip()
+    label = node.semantic_label or ""
+
+    if label.startswith("line_"):
+        for delimiter in _LINE_DELIMITERS:
+            if stripped_text.startswith(delimiter):
+                return _normalize_written_content(stripped_text[len(delimiter) :].lstrip())
+
+    if label.startswith("block_"):
+        for start, end in _BLOCK_DELIMITERS:
+            if stripped_text.startswith(start) and stripped_text.endswith(end):
+                return _normalize_written_content(stripped_text[len(start) : -len(end)].strip())
+
+    return stripped_text

--- a/src/transtructiver/mutation/rules/comment_normalization/_replacement_generator.py
+++ b/src/transtructiver/mutation/rules/comment_normalization/_replacement_generator.py
@@ -4,12 +4,15 @@ from typing import Callable
 
 from ....node import Node
 from ._context_mapping import _replace_context_mapping
+from ._format_only import _replace_format_only
 
 _ReplacementStrategy = Callable[["Node", "Node"], str]
 
-# Strategy table keyed by replacement "level"; level 0 is the current default heuristic.
+
+# Strategy table keyed by replacement "level"; level 0 keeps the comment's own content.
 _LEVEL_STRATEGIES: dict[int, _ReplacementStrategy] = {
-    0: _replace_context_mapping,
+    0: _replace_format_only,
+    1: _replace_context_mapping,
 }
 
 
@@ -17,14 +20,12 @@ class ReplacementGenerator:
     """Generate replaced comment text using a configurable replacement strategy.
 
     The strategy is selected by *level* at construction time, defaulting to
-    the context mapping heuristic (level 0).  New levels can be registered in
-    ``_LEVEL_STRATEGIES`` without touching this class.
+    the format-only normalization strategy (level 0).  New levels can be
+    registered in ``_LEVEL_STRATEGIES`` without touching this class.
     """
 
     def __init__(self, level: int = 0) -> None:
-        self._strategy: _ReplacementStrategy = _LEVEL_STRATEGIES.get(
-            level, _replace_context_mapping
-        )
+        self._strategy: _ReplacementStrategy = _LEVEL_STRATEGIES.get(level, _replace_format_only)
 
     def get_replacement(self, node: Node, ancestor: Node) -> str:
         """Return the replaced text for *node*."""

--- a/tests/mutation/rules/comment_normalization/test_comment_normalization.py
+++ b/tests/mutation/rules/comment_normalization/test_comment_normalization.py
@@ -43,13 +43,13 @@ def label_nodes(root: Node) -> Node:
     return root
 
 
-def make_line_comment_tree(length: int = 1, comment_text="// comment") -> Node:
+def make_line_comment_tree(length: int = 1, comment_text="//comment") -> Node:
     """Create a root node with a single line comment."""
     text = comment_text
     if length > 3:
-        text = "// this comment has five words"
+        text = "//this comment has five words"
     if length > 8:
-        text = "// this is a comment with more than eight words"
+        text = "//this is a comment with more than eight words"
     comment = Node((1, 0), (1, len(text)), "line_comment", text=text)
     root = Node((0, 0), (2, 0), "program", children=[comment])
     return label_nodes(root)
@@ -67,6 +67,14 @@ def make_block_comment_tree(length: int = 1, comment_text="/* comment */") -> No
     return label_nodes(root)
 
 
+def make_multiline_block_comment_tree() -> Node:
+    """Create a root node with a multiline block comment."""
+    text = "/* hello,\nworld 🚀! */"
+    comment = Node((1, 0), (2, len("world 🚀! */")), "block_comment", text=text)
+    root = Node((0, 0), (3, 0), "program", children=[comment])
+    return label_nodes(root)
+
+
 def make_python_docstring_tree(length: int = 1) -> Node:
     """Create a root node with a Python triple-quoted docstring."""
     text = "''' comment '''"
@@ -81,7 +89,7 @@ def make_python_docstring_tree(length: int = 1) -> Node:
 
 
 def make_comment_in_scope_tree(
-    scope_type="method_declaration", comment_type="line_comment", text="// comment"
+    scope_type="method_declaration", comment_type="line_comment", text="//comment"
 ) -> Node:
     """Create a scope node (function/class/loop/condition) with a comment child."""
     comment = Node((2, 0), (2, len(text)), comment_type, text=text)
@@ -93,14 +101,14 @@ def make_comment_in_scope_tree(
 def make_comment_after_terminal_tree() -> Node:
     """Create a block with a return statement followed by a comment."""
     return_stmt = Node((1, 0), (1, 6), "return_statement", text="return")
-    comment = Node((2, 0), (2, 10), "line_comment", text="// after return")
+    comment = Node((2, 0), (2, 10), "line_comment", text="//after return")
     block = Node((0, 0), (3, 0), "block", children=[return_stmt, comment])
     return label_nodes(block)
 
 
 def make_multiple_comments_tree() -> Node:
     """Create a root node with multiple comments."""
-    c1 = Node((1, 0), (1, 8), "line_comment", text="// foo")
+    c1 = Node((1, 0), (1, 8), "line_comment", text="//foo")
     c2 = Node((2, 0), (2, 8), "block_comment", text="/* bar */")
     root = Node((0, 0), (3, 0), "program", children=[c1, c2])
     return label_nodes(root)
@@ -143,25 +151,25 @@ def python_docstring_tree():
 @pytest.fixture
 def function_scope_comment_tree():
     """Returns a method_declaration node with a line comment child."""
-    return make_comment_in_scope_tree("method_declaration", "line_comment", "// in function")
+    return make_comment_in_scope_tree("method_declaration", "line_comment", "//in function")
 
 
 @pytest.fixture
 def class_scope_comment_tree():
     """Returns a class_declaration node with a line comment child."""
-    return make_comment_in_scope_tree("class_declaration", "line_comment", "// in class")
+    return make_comment_in_scope_tree("class_declaration", "line_comment", "//in class")
 
 
 @pytest.fixture
 def loop_scope_comment_tree():
     """Returns a for_statement node with a line comment child."""
-    return make_comment_in_scope_tree("for_statement", "line_comment", "// in loop")
+    return make_comment_in_scope_tree("for_statement", "line_comment", "//in loop")
 
 
 @pytest.fixture
 def condition_scope_comment_tree():
     """Returns an if_statement node with a line comment child."""
-    return make_comment_in_scope_tree("if_statement", "line_comment", "// in condition")
+    return make_comment_in_scope_tree("if_statement", "line_comment", "//in condition")
 
 
 @pytest.fixture
@@ -174,6 +182,12 @@ def comment_after_terminal_tree():
 def multiple_comments_tree():
     """Returns a program root with multiple comments."""
     return make_multiple_comments_tree()
+
+
+@pytest.fixture
+def multiline_block_comment_tree():
+    """Returns a program root with a multiline block comment."""
+    return make_multiline_block_comment_tree()
 
 
 @pytest.fixture
@@ -197,6 +211,16 @@ class TestCommentNormalizationCoreBehavior:
         """Ensure apply handles None root safely."""
         rule = CommentNormalizationRule()
         assert rule.apply(None, mutation_context) == []  # type: ignore
+
+    def test_level_one_uses_context_mapping(self, mutation_context):
+        """Level 1 should use the context-based replacement strategy."""
+        tree = make_comment_in_scope_tree("method_declaration", "line_comment", "//in function")
+        comment_text = tree.children[0].text
+        rule = CommentNormalizationRule(level=1)
+        records = rule.apply(tree, mutation_context)
+        assert len(records) == 1
+        assert "new_val" in records[0].metadata
+        assert records[0].metadata.get("new_val") != comment_text
 
     @pytest.mark.parametrize("length", [1, 4, 9])
     def test_normalizes_line_comment(self, length, mutation_context):
@@ -329,13 +353,30 @@ class TestCommentNormalizationFormatting:
 
     def test_comment_with_special_characters(self, mutation_context):
         """It normalizes comments containing special characters or unicode."""
-        tree = make_line_comment_tree(comment_text="// cömment 🚀")
+        tree = make_line_comment_tree(comment_text="//cömment 🚀")
         comment_text = tree.children[0].text
         rule = CommentNormalizationRule()
         records = rule.apply(tree, mutation_context)
         assert len(records) == 1
         assert "new_val" in records[0].metadata
         assert records[0].metadata.get("new_val") != comment_text
+
+    def test_multiline_block_comment_is_normalized(
+        self, multiline_block_comment_tree, mutation_context
+    ):
+        """It normalizes block comments that span multiple lines."""
+        comment_text = multiline_block_comment_tree.children[0].text
+        rule = CommentNormalizationRule()
+        records = rule.apply(multiline_block_comment_tree, mutation_context)
+
+        assert len(records) == 1
+        assert "new_val" in records[0].metadata
+        new_val = str(records[0].metadata.get("new_val"))
+        assert new_val != comment_text
+        assert "\n" in new_val
+        assert "hello" in new_val
+        assert "world" in new_val
+        assert "🚀" not in new_val
 
 
 class TestCommentNormalizationErrorHandling:

--- a/tests/mutation/rules/comment_normalization/test_format_only.py
+++ b/tests/mutation/rules/comment_normalization/test_format_only.py
@@ -1,0 +1,63 @@
+"""Unit tests for the format-only comment normalization strategy."""
+
+from transtructiver.node import Node
+from transtructiver.mutation.rules.comment_normalization._format_only import (
+    _replace_format_only,
+)
+
+
+def _make_node(node_type: str, text: str, semantic_label: str) -> Node:
+    node = Node((1, 0), (1, len(text)), node_type, text=text)
+    node.semantic_label = semantic_label
+    return node
+
+
+class TestReplaceFormatOnly:
+    """Direct tests for the level 0 replacement strategy."""
+
+    def test_line_comment_normalizes_spacing_without_rewriting_content(self):
+        node = _make_node("line_comment", "   //keep this text   ", "line_comment")
+
+        assert _replace_format_only(node, node) == "keep this text"
+
+    def test_block_comment_preserves_written_content(self):
+        node = _make_node("block_comment", "/* keep  this  text */", "block_comment")
+
+        assert _replace_format_only(node, node) == "keep this text"
+
+    def test_block_comment_normalizes_newlines_and_symbols(self):
+        node = _make_node(
+            "block_comment",
+            "/* hello,\nworld 🚀! */",
+            "block_comment",
+        )
+
+        assert _replace_format_only(node, node) == "hello,\nworld!"
+
+    def test_line_comment_normalizes_emojis_and_punctuation(self):
+        node = _make_node("line_comment", "// Hi there 😀!", "line_comment")
+
+        assert _replace_format_only(node, node) == "Hi there!"
+
+    def test_line_comment_keeps_hyphens_and_underscores(self):
+        node = _make_node(
+            "line_comment",
+            "// keep-this_value, please",
+            "line_comment",
+        )
+
+        assert _replace_format_only(node, node) == "keep-this_value, please"
+
+    def test_block_comment_keeps_hyphens_and_underscores(self):
+        node = _make_node(
+            "block_comment",
+            "/* build-step_value, ready */",
+            "block_comment",
+        )
+
+        assert _replace_format_only(node, node) == "build-step_value, ready"
+
+    def test_empty_comment_text_returns_empty_string(self):
+        node = _make_node("line_comment", "", "line_comment")
+
+        assert _replace_format_only(node, node) == ""


### PR DESCRIPTION
Adds a new base level (0) for comment normalization, which simply normalizes spacing and cleans up the comment text to only contain standard characters and punctuation.
`_context_mapping` is now set as level 1.