### PR TITLE
Add node serialization for mutated snippet processing and refactor da…

### DIFF
--- a/src/transtructiver/cli.py
+++ b/src/transtructiver/cli.py
@@ -119,7 +119,7 @@ _RULE_PARAM_PROPAGATIONS = {
 # PROTOTYPE-ONLY OUTPUT:
 # Keep developer-facing logs enabled in prototype runs.
 # For production hardening, set this to False (or remove related helpers/calls).
-PROTOTYPE_OUTPUT_ENABLED = True
+PROTOTYPE_OUTPUT_ENABLED = False
 
 
 @dataclass
@@ -297,15 +297,21 @@ def run_pipeline(
         max_rows_per_shard=pipeline_options.max_rows_per_shard,
         compress_output=pipeline_options.compress_output,
     ) as outputs:
-        for idx, code, language in loader.iter_snippets(
+        for idx, row in loader.iter_snippets(
             batch_size=pipeline_options.batch_size,
             start_index=start_index,
         ):
             snippet_id = f"row_{idx}"
+            code = row.get("code") or row.get("mutated_code")
+            language = row.get("language")
 
             _prototype_log(f"\n[{snippet_id}] Parsing...")
-            orig_cst, parse_err = parser.parse(code, language)
-            if orig_cst is None:
+            if not code or not language:
+                continue
+
+            start_cst, parse_err = parser.parse(code, language)
+
+            if start_cst is None:
                 stats.parse_skipped += 1
                 _prototype_log(f"  Skipped ({parse_err})")
                 processed_since_checkpoint += 1
@@ -318,21 +324,42 @@ def run_pipeline(
                 continue
 
             stats.parsed_ok += 1
-            _prototype_pretty("Original tree:", orig_cst)
+            _prototype_pretty("Original tree:", start_cst)
 
             # Clone before mutation so we keep the clean original for comparison
-            mut_cst = orig_cst.clone()
+            mut_cst = start_cst.clone()
             engine.apply_mutations(mut_cst)
 
             _prototype_pretty("\nMutated code:", mut_cst)
+
+            cached_original_cst = row.get("original_cst")
+            if cached_original_cst:
+                orig_cst = Node.from_json(cached_original_cst)
+            else:
+                orig_cst = start_cst
 
             # Write manifest for this snippet
             outputs.write_manifest(idx, snippet_id, engine.manifest.to_dict())
 
             # Write original/mutated code pair
-            original_code = orig_cst.to_code()
+            original_code = start_cst.to_code()
             mutated_code = mut_cst.to_code()
-            outputs.write_dataset_row(idx, snippet_id, original_code, mutated_code, language)
+
+            # Keep all other metadata fields from the original row, except code/language which we handle separately
+            metadata = dict(row)
+            metadata.pop("code", None)
+            metadata.pop("language", None)
+            is_mutated = engine.manifest.is_empty() is False
+            outputs.write_dataset_row(
+                idx,
+                snippet_id,
+                original_code,
+                mutated_code,
+                language,
+                has_mutation_applied=not engine.manifest.is_empty(),
+                metadata=metadata,
+                original_cst=orig_cst,
+            )
 
             # Verify semantic preservation and append to summary log
             verified = verifier.verify(orig_cst, mut_cst, engine.manifest)

--- a/src/transtructiver/data_loading/data_loader.py
+++ b/src/transtructiver/data_loading/data_loader.py
@@ -110,23 +110,26 @@ class ParquetDataLoader(AbstractDataLoader):
     Implements iter_snippets() for efficient batch streaming.
     """
 
-    def iter_snippets(self, batch_size: int, start_index: int) -> Iterator[tuple[int, str, str]]:
-        """Stream snippets from parquet in bounded-size batches.
+    def iter_snippets(self, batch_size: int, start_index: int) -> Iterator[tuple[int, dict]]:
+        """
+        Stream full rows from parquet, preserving all metadata.
 
         Args:
             batch_size (int): Number of rows per batch.
             start_index (int): Index to start streaming from.
 
         Returns:
-            Iterator[tuple[int, str, str]]: Yields (global_index, code, language).
+            Iterator[tuple[int, dict]]: Yields (global_index, row_dict).
         """
+
         parquet_file = pq.ParquetFile(self.filepath)
         global_index = 0
-        for batch in parquet_file.iter_batches(batch_size=batch_size, columns=["code", "language"]):
-            batch_dict = batch.to_pydict()
-            codes = batch_dict.get("code", [])
-            languages = batch_dict.get("language", [])
-            for code, language in zip(codes, languages):
+
+        for batch in parquet_file.iter_batches(batch_size=batch_size):
+            df = batch.to_pandas()
+
+            for _, row in df.iterrows():
                 if global_index >= start_index:
-                    yield global_index, code, language
+                    yield global_index, row.to_dict()
+
                 global_index += 1

--- a/src/transtructiver/mutation/mutation_manifest.py
+++ b/src/transtructiver/mutation/mutation_manifest.py
@@ -143,3 +143,12 @@ class MutationManifest:
                 }
             )
         return result
+
+    def is_empty(self) -> bool:
+        """
+        Checks if the manifest has any recorded mutations.
+
+        Returns:
+            bool: True if no entries have been added; False otherwise.
+        """
+        return len(self._entries) == 0

--- a/src/transtructiver/node.py
+++ b/src/transtructiver/node.py
@@ -5,7 +5,8 @@ This module defines the fundamental Node class used throughout the project
 to represent hierarchical code structures.
 """
 
-from typing import Iterator, List, Optional
+import json
+from typing import Any, Iterator, List, Optional
 
 
 class Node:
@@ -114,6 +115,62 @@ class Node:
         new_node.children = [child.clone(new_node) for child in self.children]
 
         return new_node
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this node and its subtree to plain Python data.
+
+        Parent links are intentionally excluded because they are derived from
+        the child structure and would create cycles in a serialized format.
+        """
+
+        return {
+            "start_point": list(self.start_point),
+            "end_point": list(self.end_point),
+            "type": self.type,
+            "text": self.text,
+            "semantic_label": self.semantic_label,
+            "context_type": self.context_type,
+            "field": self.field,
+            "language": self.language,
+            "builtin": self.builtin,
+            "is_named": self.is_named,
+            "children": [child.to_dict() for child in self.children],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any], parent: Optional[Node] = None) -> Node:
+        """Rebuild a node tree from :meth:`to_dict` output."""
+        node = cls(
+            start_point=tuple(payload["start_point"]),
+            end_point=tuple(payload["end_point"]),
+            type=payload["type"],
+            text=payload.get("text"),
+            children=[],
+        )
+        node.semantic_label = payload.get("semantic_label")
+        node.context_type = payload.get("context_type")
+        node.field = payload.get("field")
+        node.language = payload.get("language")
+        node.builtin = bool(payload.get("builtin", False))
+        node.is_named = bool(payload.get("is_named", True))
+        node.parent = parent
+
+        for child_payload in payload.get("children", []):
+            child = cls.from_dict(child_payload, node)
+            node.children.append(child)
+
+        return node
+
+    def to_json(self) -> str:
+        """Serialize this node tree to a JSON string."""
+
+        return json.dumps(self.to_dict(), ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, payload: str) -> Node:
+        """Deserialize a JSON string produced by :meth:`to_json`."""
+
+        return cls.from_dict(json.loads(payload))
 
     def __repr__(self) -> str:
         """

--- a/src/transtructiver/reporting/output_manager.py
+++ b/src/transtructiver/reporting/output_manager.py
@@ -19,6 +19,8 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from ..node import Node
+
 
 @dataclass
 class RunStats:
@@ -146,7 +148,7 @@ class OutputManager:
             return os.path.join(self.output_dir, "augmented_dataset.parquet")
         return os.path.join(self.output_dir, f"augmented_dataset-{shard_id:06d}.parquet")
 
-    def _ensure_shard(self, snippet_index: int) -> None:
+    def _ensure_shard(self, snippet_index: int, metadata: dict | None = None) -> None:
         """Rotate output handles when shard boundary changes.
 
         Args:
@@ -175,9 +177,15 @@ class OutputManager:
                 ("snippet_id", pa.string()),
                 ("original_code", pa.string()),
                 ("mutated_code", pa.string()),
+                ("original_cst", pa.string()),
                 ("language", pa.string()),
+                ("has_mutation_applied", pa.bool_()),
             ]
         )
+
+        if metadata:
+            schema.with_metadata(metadata)
+
         compression = "gzip" if self.compress_output else "snappy"
         self.dataset_parquet_writer = pq.ParquetWriter(
             dataset_parquet_path,
@@ -210,6 +218,9 @@ class OutputManager:
         original_code: str,
         mutated_code: str,
         language: str,
+        has_mutation_applied: bool = False,
+        metadata: dict | None = None,
+        original_cst: Node | None = None,
     ) -> None:
         """Append one original/mutated code pair row to parquet output.
 
@@ -218,18 +229,29 @@ class OutputManager:
             snippet_id (str): Unique snippet identifier.
             original_code (str): Original code string.
             mutated_code (str): Mutated code string.
+            language (str): Programming language of the snippet.
+            has_mutation_applied (bool): Whether any mutation was applied.
+            metadata (dict | None): Additional dataset metadata (e.g., char_count, lloc, label).
+            original_cst (Node | None): Original CST to cache for later tiers.
         """
-        self._ensure_shard(snippet_index)
+
+        # Base row (core schema)
+        row_dict = {
+            "snippet_id": [snippet_id],
+            "original_code": [original_code],
+            "mutated_code": [mutated_code],
+            "original_cst": [original_cst.to_json() if original_cst else None],
+            "language": [language],
+            "has_mutation_applied": [has_mutation_applied],
+        }
+
+        self._ensure_shard(snippet_index, metadata)
+
         if self.dataset_parquet_writer is None:
             raise RuntimeError("Parquet dataset writer is not initialized.")
-        table = pa.table(
-            {
-                "snippet_id": [snippet_id],
-                "original_code": [original_code],
-                "mutated_code": [mutated_code],
-                "language": [language],
-            }
-        )
+
+        table = pa.table(row_dict, schema=self.dataset_parquet_writer.schema)
+
         self.dataset_parquet_writer.write_table(table)
 
     def output_paths_summary(self) -> tuple[str, str, str]:

--- a/tests/data_loading/test_data_loader.py
+++ b/tests/data_loading/test_data_loader.py
@@ -52,14 +52,7 @@ def test_load_successful(sample_parquet):
     # Use iter_snippets to stream rows
     streamed = list(loader.iter_snippets(batch_size=10, start_index=0))
     # Convert streamed output to DataFrame for comparison
-    indices, codes, languages = zip(*streamed)
-    df_streamed = pd.DataFrame(
-        {
-            "index": indices,
-            "code": codes,
-            "language": languages,
-        }
-    )
+    df_streamed = pd.DataFrame([row for _, row in streamed])
     # Compare streamed DataFrame to original
     pd.testing.assert_frame_equal(
         df_streamed.reset_index(drop=True), original_df.reset_index(drop=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ def test_run_pipeline_happy_path_writes_artifacts_and_summary(monkeypatch, tmp_p
             save_calls.append((next_index, stats.parsed_ok, stats.verified_ok, stats.verified_fail))
 
         def iter_snippets(self, batch_size, start_index):
-            return [(0, "print(1)", "python")]
+            return [(0, {"snippet_id": "row_0", "code": "print(1)", "language": "python"})]
 
     class DummyNode:
         def __init__(self, code):
@@ -47,6 +47,10 @@ def test_run_pipeline_happy_path_writes_artifacts_and_summary(monkeypatch, tmp_p
     class FakeManifest:
         def to_dict(self):
             return [{"node_id": [0, 0], "history": [], "metadata": {}}]
+
+        def is_empty(self):
+            # Return True when manifest has no entries
+            return len(self.to_dict()) == 0
 
     class FakeEngine:
         def __init__(self):
@@ -80,8 +84,41 @@ def test_run_pipeline_happy_path_writes_artifacts_and_summary(monkeypatch, tmp_p
         def write_manifest(self, idx, snippet_id, entries):
             self.manifest_calls.append((idx, snippet_id, entries))
 
-        def write_dataset_row(self, idx, snippet_id, original_code, mutated_code, language):
-            self.dataset_calls.append((idx, snippet_id, original_code, mutated_code, language))
+        def write_dataset_row(
+            self,
+            snippet_idx,
+            snippet_id,
+            original_code,
+            mutated_code,
+            language,
+            has_mutation_applied,
+            metadata,
+            original_cst=None,
+        ):
+            metadata = {
+                "char_count": 1,
+                "loc": 1,
+                "lloc": 1,
+                "for_loop_density": 0.1,
+                "identifier_density": 0.1,
+                "comment_density": 0.1,
+                "whitespace_ratio": 0.1,
+                "code_hash": "x",
+                "label": "y",
+            }
+
+            self.dataset_calls.append(
+                (
+                    snippet_idx,
+                    snippet_id,
+                    original_code,
+                    mutated_code,
+                    language,
+                    has_mutation_applied,
+                    metadata,
+                    original_cst,
+                )
+            )
 
         def output_paths_summary(self):
             return ("manifest.jsonl", "augmented_dataset.parquet", "summary_log.csv")
@@ -164,7 +201,7 @@ def test_run_pipeline_integration_writes_real_outputs(monkeypatch, tmp_path):
                 json.dump(payload, f)
 
         def iter_snippets(self, batch_size, start_index):
-            return [(0, snippet, "python")]
+            return [(0, {"snippet_id": "row_0", "code": snippet, "language": "python"})]
 
     snippet = "def add(a, b):\n    return a + b\n"
     monkeypatch.setattr(module, "_prototype_log", lambda *_args, **_kwargs: None)
@@ -178,6 +215,84 @@ def test_run_pipeline_integration_writes_real_outputs(monkeypatch, tmp_path):
     module.run_pipeline(
         filepath="ignored.parquet",
         rules=["rename-identifier"],
+        output_dir=str(output_dir),
+        pipeline_options=options,
+    )
+
+    manifest_file = output_dir / "manifest.jsonl"
+    dataset_file = output_dir / "augmented_dataset.parquet"
+    summary_file = output_dir / "summary_log.csv"
+
+    assert manifest_file.exists()
+    assert dataset_file.exists()
+    assert summary_file.exists()
+    assert checkpoint_path.exists()
+
+    manifest_row = json.loads(manifest_file.read_text(encoding="utf-8").splitlines()[0])
+    assert manifest_row["snippet_id"] == "row_0"
+
+    summary_rows = summary_file.read_text(encoding="utf-8").splitlines()
+    assert summary_rows[0].startswith("row_0,")
+    assert summary_rows[1].startswith("TOTAL,")
+
+
+def test_run_pipeline_use_cached_original_cst_on_mutated_code(monkeypatch, tmp_path):
+    module = importlib.import_module("transtructiver.cli")
+
+    class DummyLoader:
+        def __init__(self, *args, **kwargs):
+            self.checkpoint_path = str(checkpoint_path)
+
+        def load_checkpoint(self, resume):
+            return 0
+
+        def save_checkpoint(self, next_index, stats):
+            # Actually write a checkpoint file so the test can check for it
+            payload = {"next_index": next_index}
+            with open(self.checkpoint_path, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+
+        def iter_snippets(self, batch_size, start_index):
+            return [
+                (
+                    0,
+                    {
+                        "snippet_id": "row_0",
+                        "original_code": snippet,
+                        "mutated_code": mut_snippet,
+                        "language": "python",
+                        "original_cst": json_cst,
+                    },
+                )
+            ]
+
+    snippet = "def add(a, b):\n    return a + b\n"
+    mut_snippet = "def add_func(a_var, b_var):\n    return a_var + b_var\n"
+    orig_cst = {
+        "start_point": (0, 0),
+        "end_point": (0, len(snippet)),
+        "type": "module",
+        "text": snippet,
+        "semantic_label": "root",
+        "context_type": None,
+        "field": None,
+        "language": "python",
+        "builtin": False,
+        "is_named": True,
+        "children": [],
+    }
+    json_cst = json.dumps(orig_cst, ensure_ascii=False)
+    monkeypatch.setattr(module, "_prototype_log", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "_prototype_pretty", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "DataLoader", lambda *args, **kwargs: DummyLoader())
+
+    output_dir = tmp_path / "out"
+    checkpoint_path = tmp_path / "checkpoint.json"
+    options = module.PipelineOptions(checkpoint_path=str(checkpoint_path), checkpoint_every=1000)
+
+    module.run_pipeline(
+        filepath="ignored.parquet",
+        rules=["whitespace-normalization"],
         output_dir=str(output_dir),
         pipeline_options=options,
     )

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -161,6 +161,33 @@ def test_clone_preserves_parent_relationships():
     assert cloned_grandchild.parent is not child
 
 
+def test_node_json_round_trip_preserves_tree_shape_and_metadata():
+    """Verify that Node JSON serialization can reconstruct the full tree."""
+    point = (0, 0)
+
+    root = Node(point, point, "root")
+    root.language = "python"
+    root.semantic_label = "module_root"
+
+    child = Node(point, point, "identifier", text="x")
+    child.field = "name"
+    child.context_type = "binding"
+    child.builtin = True
+    root.add_child(child)
+    child.parent = root
+
+    restored = Node.from_json(root.to_json())
+
+    assert restored.type == "root"
+    assert restored.language == "python"
+    assert restored.semantic_label == "module_root"
+    assert restored.children[0].text == "x"
+    assert restored.children[0].field == "name"
+    assert restored.children[0].context_type == "binding"
+    assert restored.children[0].builtin is True
+    assert restored.children[0].parent is restored
+
+
 def test_node_with_multiple_children_init():
     """Verify initializing a node with a pre-defined list of children."""
     point = (0, 0)


### PR DESCRIPTION
**Node (CST) Serialization and Deserialization**
- Added `to_dict`, `from_dict`, `to_json`, and `from_json` methods to the `Node` class, enabling robust serialization and deserialization of code structure trees, including all metadata except parent links (which are reconstructed). This allows CSTs to be cached and restored as part of the pipeline and output.

**Pipeline Refactoring for Metadata and CST Handling**
- When available, uses a cached `original_cst` from the row for semantic verification and output, otherwise falls back to parsing the current code.
- Passes through and writes all extra metadata fields (except code/language) to the output, and writes the original CST as a JSON string for each snippet.